### PR TITLE
Support #19431 - Add initial groups and roles to local-deployment

### DIFF
--- a/keycloak-dina-starter-realm.json
+++ b/keycloak-dina-starter-realm.json
@@ -485,7 +485,7 @@
       "username": "user",
       "enabled": true,
       "realmRoles": ["user"],
-      "groups": ["aafc", "entomology"],
+      "groups": ["aafc", "cnc"],
       "credentials": [{ "type": "password", "value": "user" }],
       "attributes": {
         "agentId": "9c403c4b-c849-43c4-bbc1-8bd10b1997e1"


### PR DESCRIPTION
Added groups "aafc", "mycology" and "entomology". Added a protocol mapper that adds a "groups" claim in the access token. Enrolled user "user" in aafc and entomology groups.