### PR TITLE
Support #20022 - Change login options to show AAFC first

### DIFF
--- a/dina-keycloak-theme/login/login.ftl
+++ b/dina-keycloak-theme/login/login.ftl
@@ -1,0 +1,76 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayInfo=social.displayInfo displayWide=(realm.password && social.providers??); section>
+    <#if section = "header">
+        ${msg("doLogIn")}
+    <#elseif section = "form">
+    <div id="kc-form" <#if realm.password && social.providers??>class="${properties.kcContentWrapperClass!}"</#if>>
+        <!-- social providers -->
+        <#if realm.password && social.providers??>
+            <div id="kc-social-providers" class="${properties.kcFormSocialAccountContentClass!} ${properties.kcFormSocialAccountClass!}">
+                <ul class="${properties.kcFormSocialAccountListClass!} <#if social.providers?size gt 4>${properties.kcFormSocialAccountDoubleListClass!}</#if>">
+                    <#list social.providers as p>
+                        <li class="${properties.kcFormSocialAccountListLinkClass!}"><a href="${p.loginUrl}" id="zocial-${p.alias}" class="zocial ${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!} ${p.providerId}"> <span>${p.displayName}</span></a></li>
+                    </#list>
+                </ul>
+            </div>
+        </#if>
+        <!-- /social providers -->
+      <!-- kc-form-wrapper -->
+      <div id="kc-form-wrapper" <#if realm.password && social.providers??>class="${properties.kcFormSocialAccountContentClass!} ${properties.kcFormSocialAccountClass!}"</#if>>
+        <#if realm.password>
+            <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
+                <div class="${properties.kcFormGroupClass!}">
+                    <label for="username" class="${properties.kcLabelClass!}"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>
+
+                    <#if usernameEditDisabled??>
+                        <input tabindex="1" id="username" class="${properties.kcInputClass!}" name="username" value="${(login.username!'')}" type="text" disabled />
+                    <#else>
+                        <input tabindex="1" id="username" class="${properties.kcInputClass!}" name="username" value="${(login.username!'')}"  type="text" autofocus autocomplete="off" />
+                    </#if>
+                </div>
+
+                <div class="${properties.kcFormGroupClass!}">
+                    <label for="password" class="${properties.kcLabelClass!}">${msg("password")}</label>
+                    <input tabindex="2" id="password" class="${properties.kcInputClass!}" name="password" type="password" autocomplete="off" />
+                </div>
+
+                <div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
+                    <div id="kc-form-options">
+                        <#if realm.rememberMe && !usernameEditDisabled??>
+                            <div class="checkbox">
+                                <label>
+                                    <#if login.rememberMe??>
+                                        <input tabindex="3" id="rememberMe" name="rememberMe" type="checkbox" checked> ${msg("rememberMe")}
+                                    <#else>
+                                        <input tabindex="3" id="rememberMe" name="rememberMe" type="checkbox"> ${msg("rememberMe")}
+                                    </#if>
+                                </label>
+                            </div>
+                        </#if>
+                        </div>
+                        <div class="${properties.kcFormOptionsWrapperClass!}">
+                            <#if realm.resetPasswordAllowed>
+                                <span><a tabindex="5" href="${url.loginResetCredentialsUrl}">${msg("doForgotPassword")}</a></span>
+                            </#if>
+                        </div>
+
+                  </div>
+
+                  <div id="kc-form-buttons" class="${properties.kcFormGroupClass!}">
+                      <input type="hidden" id="id-hidden-input" name="credentialId" <#if auth.selectedCredential?has_content>value="${auth.selectedCredential}"</#if>/>
+                      <input tabindex="4" class="${properties.kcButtonClass!} <#if !social.providers??> ${properties.kcButtonPrimaryClass!} </#if> ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
+                  </div>
+            </form>
+        </#if>
+        </div>
+        <!-- /kc-form-wrapper -->
+      </div>
+    <#elseif section = "info" >
+        <#if realm.password && realm.registrationAllowed && !registrationDisabled??>
+            <div id="kc-registration">
+                <span>${msg("noAccount")} <a tabindex="6" href="${url.registrationUrl}">${msg("doRegister")}</a></span>
+            </div>
+        </#if>
+    </#if>
+
+</@layout.registrationLayout>

--- a/dina-keycloak-theme/login/resources/css/dina-login.css
+++ b/dina-keycloak-theme/login/resources/css/dina-login.css
@@ -12,3 +12,420 @@ div.kc-logo-text {
     width: 100%;
     margin: 0 auto;
 }
+
+.login-pf-social-link a.btn:focus,
+.login-pf-social-link a.btn:active:focus,
+.login-pf-social-link a.btn.active:focus,
+.login-pf-social-link a.btn.focus,
+.login-pf-social-link a.btn:active.focus,
+.login-pf-social-link a.btn.active.focus {
+  outline: 5px auto -webkit-focus-ring-color;
+  outline-offset: -2px;
+}
+.login-pf-social-link a.btn:hover,
+.login-pf-social-link a.btn:focus,
+.login-pf-social-link a.btn.focus {
+  color: #4d5258;
+  text-decoration: none;
+}
+.login-pf-social-link a.btn:active,
+.login-pf-social-link a.btn.active {
+  background-image: none;
+  outline: 0;
+  box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+}
+.login-pf-social-link a.btn.disabled,
+.login-pf-social-link a.btn[disabled],
+fieldset[disabled] .login-pf-social-link a.btn {
+  cursor: not-allowed;
+  filter: alpha(opacity=65);
+  opacity: 0.65;
+  box-shadow: none;
+}
+a.login-pf-social-link a.btn.disabled,
+fieldset[disabled] a.login-pf-social-link a.btn {
+  pointer-events: none;
+}
+.login-pf-social-link a.btn-default {
+  color: #4d5258;
+  background-color: #f1f1f1;
+  border-color: #bbb;
+}
+.login-pf-social-link a.btn-default:focus,
+.login-pf-social-link a.btn-default.focus {
+  color: #4d5258;
+  background-color: #d8d8d8;
+  border-color: #7b7b7b;
+}
+.login-pf-social-link a.btn-default:hover {
+  color: #4d5258;
+  background-color: #d8d8d8;
+  border-color: #9c9c9c;
+}
+.login-pf-social-link a.btn-default:active,
+.login-pf-social-link a.btn-default.active,
+.open > .dropdown-toggle.login-pf-social-link a.btn-default {
+  color: #4d5258;
+  background-color: #d8d8d8;
+  background-image: none;
+  border-color: #9c9c9c;
+}
+.login-pf-social-link a.btn-default:active:hover,
+.login-pf-social-link a.btn-default.active:hover,
+.open > .dropdown-toggle.login-pf-social-link a.btn-default:hover,
+.login-pf-social-link a.btn-default:active:focus,
+.login-pf-social-link a.btn-default.active:focus,
+.open > .dropdown-toggle.login-pf-social-link a.btn-default:focus,
+.login-pf-social-link a.btn-default:active.focus,
+.login-pf-social-link a.btn-default.active.focus,
+.open > .dropdown-toggle.login-pf-social-link a.btn-default.focus {
+  color: #4d5258;
+  background-color: #c6c6c6;
+  border-color: #7b7b7b;
+}
+.login-pf-social-link a.btn-default.disabled:hover,
+.login-pf-social-link a.btn-default[disabled]:hover,
+fieldset[disabled] .login-pf-social-link a.btn-default:hover,
+.login-pf-social-link a.btn-default.disabled:focus,
+.login-pf-social-link a.btn-default[disabled]:focus,
+fieldset[disabled] .login-pf-social-link a.btn-default:focus,
+.login-pf-social-link a.btn-default.disabled.focus,
+.login-pf-social-link a.btn-default[disabled].focus,
+fieldset[disabled] .login-pf-social-link a.btn-default.focus {
+  background-color: #f1f1f1;
+  border-color: #bbb;
+}
+.login-pf-social-link a.btn-default .badge {
+  color: #f1f1f1;
+  background-color: #4d5258;
+}
+.login-pf-social-link a.btn-primary {
+  color: #fff;
+  background-color: #0088ce;
+  border-color: #00659c;
+}
+.login-pf-social-link a.btn-primary:focus,
+.login-pf-social-link a.btn-primary.focus {
+  color: #fff;
+  background-color: #00669b;
+  border-color: #00121d;
+}
+.login-pf-social-link a.btn-primary:hover {
+  color: #fff;
+  background-color: #00669b;
+  border-color: #003d5f;
+}
+.login-pf-social-link a.btn-primary:active,
+.login-pf-social-link a.btn-primary.active,
+.open > .dropdown-toggle.login-pf-social-link a.btn-primary {
+  color: #fff;
+  background-color: #00669b;
+  background-image: none;
+  border-color: #003d5f;
+}
+.login-pf-social-link a.btn-primary:active:hover,
+.login-pf-social-link a.btn-primary.active:hover,
+.open > .dropdown-toggle.login-pf-social-link a.btn-primary:hover,
+.login-pf-social-link a.btn-primary:active:focus,
+.login-pf-social-link a.btn-primary.active:focus,
+.open > .dropdown-toggle.login-pf-social-link a.btn-primary:focus,
+.login-pf-social-link a.btn-primary:active.focus,
+.login-pf-social-link a.btn-primary.active.focus,
+.open > .dropdown-toggle.login-pf-social-link a.btn-primary.focus {
+  color: #fff;
+  background-color: #004f77;
+  border-color: #00121d;
+}
+.login-pf-social-link a.btn-primary.disabled:hover,
+.login-pf-social-link a.btn-primary[disabled]:hover,
+fieldset[disabled] .login-pf-social-link a.btn-primary:hover,
+.login-pf-social-link a.btn-primary.disabled:focus,
+.login-pf-social-link a.btn-primary[disabled]:focus,
+fieldset[disabled] .login-pf-social-link a.btn-primary:focus,
+.login-pf-social-link a.btn-primary.disabled.focus,
+.login-pf-social-link a.btn-primary[disabled].focus,
+fieldset[disabled] .login-pf-social-link a.btn-primary.focus {
+  background-color: #0088ce;
+  border-color: #00659c;
+}
+.login-pf-social-link a.btn-primary .badge {
+  color: #0088ce;
+  background-color: #fff;
+}
+.login-pf-social-link a.btn-success {
+  color: #fff;
+  background-color: #3f9c35;
+  border-color: #37892f;
+}
+.login-pf-social-link a.btn-success:focus,
+.login-pf-social-link a.btn-success.focus {
+  color: #fff;
+  background-color: #307628;
+  border-color: #112a0e;
+}
+.login-pf-social-link a.btn-success:hover {
+  color: #fff;
+  background-color: #307628;
+  border-color: #255b1f;
+}
+.login-pf-social-link a.btn-success:active,
+.login-pf-social-link a.btn-success.active,
+.open > .dropdown-toggle.login-pf-social-link a.btn-success {
+  color: #fff;
+  background-color: #307628;
+  background-image: none;
+  border-color: #255b1f;
+}
+.login-pf-social-link a.btn-success:active:hover,
+.login-pf-social-link a.btn-success.active:hover,
+.open > .dropdown-toggle.login-pf-social-link a.btn-success:hover,
+.login-pf-social-link a.btn-success:active:focus,
+.login-pf-social-link a.btn-success.active:focus,
+.open > .dropdown-toggle.login-pf-social-link a.btn-success:focus,
+.login-pf-social-link a.btn-success:active.focus,
+.login-pf-social-link a.btn-success.active.focus,
+.open > .dropdown-toggle.login-pf-social-link a.btn-success.focus {
+  color: #fff;
+  background-color: #255b1f;
+  border-color: #112a0e;
+}
+.login-pf-social-link a.btn-success.disabled:hover,
+.login-pf-social-link a.btn-success[disabled]:hover,
+fieldset[disabled] .login-pf-social-link a.btn-success:hover,
+.login-pf-social-link a.btn-success.disabled:focus,
+.login-pf-social-link a.btn-success[disabled]:focus,
+fieldset[disabled] .login-pf-social-link a.btn-success:focus,
+.login-pf-social-link a.btn-success.disabled.focus,
+.login-pf-social-link a.btn-success[disabled].focus,
+fieldset[disabled] .login-pf-social-link a.btn-success.focus {
+  background-color: #3f9c35;
+  border-color: #37892f;
+}
+.login-pf-social-link a.btn-success .badge {
+  color: #3f9c35;
+  background-color: #fff;
+}
+.login-pf-social-link a.btn-info {
+  color: #fff;
+  background-color: #00659c;
+  border-color: #005483;
+}
+.login-pf-social-link a.btn-info:focus,
+.login-pf-social-link a.btn-info.focus {
+  color: #fff;
+  background-color: #004469;
+  border-color: #000203;
+}
+.login-pf-social-link a.btn-info:hover {
+  color: #fff;
+  background-color: #004469;
+  border-color: #002d45;
+}
+.login-pf-social-link a.btn-info:active,
+.login-pf-social-link a.btn-info.active,
+.open > .dropdown-toggle.login-pf-social-link a.btn-info {
+  color: #fff;
+  background-color: #004469;
+  background-image: none;
+  border-color: #002d45;
+}
+.login-pf-social-link a.btn-info:active:hover,
+.login-pf-social-link a.btn-info.active:hover,
+.open > .dropdown-toggle.login-pf-social-link a.btn-info:hover,
+.login-pf-social-link a.btn-info:active:focus,
+.login-pf-social-link a.btn-info.active:focus,
+.open > .dropdown-toggle.login-pf-social-link a.btn-info:focus,
+.login-pf-social-link a.btn-info:active.focus,
+.login-pf-social-link a.btn-info.active.focus,
+.open > .dropdown-toggle.login-pf-social-link a.btn-info.focus {
+  color: #fff;
+  background-color: #002d45;
+  border-color: #000203;
+}
+.login-pf-social-link a.btn-info.disabled:hover,
+.login-pf-social-link a.btn-info[disabled]:hover,
+fieldset[disabled] .login-pf-social-link a.btn-info:hover,
+.login-pf-social-link a.btn-info.disabled:focus,
+.login-pf-social-link a.btn-info[disabled]:focus,
+fieldset[disabled] .login-pf-social-link a.btn-info:focus,
+.login-pf-social-link a.btn-info.disabled.focus,
+.login-pf-social-link a.btn-info[disabled].focus,
+fieldset[disabled] .login-pf-social-link a.btn-info.focus {
+  background-color: #00659c;
+  border-color: #005483;
+}
+.login-pf-social-link a.btn-info .badge {
+  color: #00659c;
+  background-color: #fff;
+}
+.login-pf-social-link a.btn-warning {
+  color: #fff;
+  background-color: #ec7a08;
+  border-color: #d36d07;
+}
+.login-pf-social-link a.btn-warning:focus,
+.login-pf-social-link a.btn-warning.focus {
+  color: #fff;
+  background-color: #bb6106;
+  border-color: #582e03;
+}
+.login-pf-social-link a.btn-warning:hover {
+  color: #fff;
+  background-color: #bb6106;
+  border-color: #984f05;
+}
+.login-pf-social-link a.btn-warning:active,
+.login-pf-social-link a.btn-warning.active,
+.open > .dropdown-toggle.login-pf-social-link a.btn-warning {
+  color: #fff;
+  background-color: #bb6106;
+  background-image: none;
+  border-color: #984f05;
+}
+.login-pf-social-link a.btn-warning:active:hover,
+.login-pf-social-link a.btn-warning.active:hover,
+.open > .dropdown-toggle.login-pf-social-link a.btn-warning:hover,
+.login-pf-social-link a.btn-warning:active:focus,
+.login-pf-social-link a.btn-warning.active:focus,
+.open > .dropdown-toggle.login-pf-social-link a.btn-warning:focus,
+.login-pf-social-link a.btn-warning:active.focus,
+.login-pf-social-link a.btn-warning.active.focus,
+.open > .dropdown-toggle.login-pf-social-link a.btn-warning.focus {
+  color: #fff;
+  background-color: #984f05;
+  border-color: #582e03;
+}
+.login-pf-social-link a.btn-warning.disabled:hover,
+.login-pf-social-link a.btn-warning[disabled]:hover,
+fieldset[disabled] .login-pf-social-link a.btn-warning:hover,
+.login-pf-social-link a.btn-warning.disabled:focus,
+.login-pf-social-link a.btn-warning[disabled]:focus,
+fieldset[disabled] .login-pf-social-link a.btn-warning:focus,
+.login-pf-social-link a.btn-warning.disabled.focus,
+.login-pf-social-link a.btn-warning[disabled].focus,
+fieldset[disabled] .login-pf-social-link a.btn-warning.focus {
+  background-color: #ec7a08;
+  border-color: #d36d07;
+}
+.login-pf-social-link a.btn-warning .badge {
+  color: #ec7a08;
+  background-color: #fff;
+}
+.login-pf-social-link a.btn-danger {
+  color: #fff;
+  background-color: #a30000;
+  border-color: #8b0000;
+}
+.login-pf-social-link a.btn-danger:focus,
+.login-pf-social-link a.btn-danger.focus {
+  color: #fff;
+  background-color: #700000;
+  border-color: #0b0000;
+}
+.login-pf-social-link a.btn-danger:hover {
+  color: #fff;
+  background-color: #700000;
+  border-color: #4e0000;
+}
+.login-pf-social-link a.btn-danger:active,
+.login-pf-social-link a.btn-danger.active,
+.open > .dropdown-toggle.login-pf-social-link a.btn-danger {
+  color: #fff;
+  background-color: #700000;
+  background-image: none;
+  border-color: #4e0000;
+}
+.login-pf-social-link a.btn-danger:active:hover,
+.login-pf-social-link a.btn-danger.active:hover,
+.open > .dropdown-toggle.login-pf-social-link a.btn-danger:hover,
+.login-pf-social-link a.btn-danger:active:focus,
+.login-pf-social-link a.btn-danger.active:focus,
+.open > .dropdown-toggle.login-pf-social-link a.btn-danger:focus,
+.login-pf-social-link a.btn-danger:active.focus,
+.login-pf-social-link a.btn-danger.active.focus,
+.open > .dropdown-toggle.login-pf-social-link a.btn-danger.focus {
+  color: #fff;
+  background-color: #4c0000;
+  border-color: #0b0000;
+}
+.login-pf-social-link a.btn-danger.disabled:hover,
+.login-pf-social-link a.btn-danger[disabled]:hover,
+fieldset[disabled] .login-pf-social-link a.btn-danger:hover,
+.login-pf-social-link a.btn-danger.disabled:focus,
+.login-pf-social-link a.btn-danger[disabled]:focus,
+fieldset[disabled] .login-pf-social-link a.btn-danger:focus,
+.login-pf-social-link a.btn-danger.disabled.focus,
+.login-pf-social-link a.btn-danger[disabled].focus,
+fieldset[disabled] .login-pf-social-link a.btn-danger.focus {
+  background-color: #a30000;
+  border-color: #8b0000;
+}
+.login-pf-social-link a.btn-danger .badge {
+  color: #a30000;
+  background-color: #fff;
+}
+.login-pf-social-link a.btn-link {
+  font-weight: 400;
+  color: #0088ce;
+  border-radius: 0;
+}
+.login-pf-social-link a.btn-link,
+.login-pf-social-link a.btn-link:active,
+.login-pf-social-link a.btn-link.active,
+.login-pf-social-link a.btn-link[disabled],
+fieldset[disabled] .login-pf-social-link a.btn-link {
+  background-color: transparent;
+  box-shadow: none;
+}
+.login-pf-social-link a.btn-link,
+.login-pf-social-link a.btn-link:hover,
+.login-pf-social-link a.btn-link:focus,
+.login-pf-social-link a.btn-link:active {
+  border-color: transparent;
+}
+.login-pf-social-link a.btn-link:hover,
+.login-pf-social-link a.btn-link:focus {
+  color: #00659c;
+  text-decoration: underline;
+  background-color: transparent;
+}
+.login-pf-social-link a.btn-link[disabled]:hover,
+fieldset[disabled] .login-pf-social-link a.btn-link:hover,
+.login-pf-social-link a.btn-link[disabled]:focus,
+fieldset[disabled] .login-pf-social-link a.btn-link:focus {
+  color: #9c9c9c;
+  text-decoration: none;
+}
+.login-pf-social-link a.btn-lg,
+.login-pf-social-link a.btn-group-lg > .login-pf-social-link a.btn {
+  padding: 6px 10px;
+  font-size: 14px;
+  line-height: 1.3333333;
+  border-radius: 1px;
+}
+.login-pf-social-link a.btn-sm,
+.login-pf-social-link a.btn-group-sm > .login-pf-social-link a.btn {
+  padding: 2px 6px;
+  font-size: 11px;
+  line-height: 1.5;
+  border-radius: 1px;
+}
+.login-pf-social-link a.btn-xs,
+.login-pf-social-link a.btn-group-xs > .login-pf-social-link a.btn {
+  padding: 1px 5px;
+  font-size: 11px;
+  line-height: 1.5;
+  border-radius: 1px;
+}
+.login-pf-social-link a.btn-block {
+  display: block;
+  width: 100%;
+}
+.login-pf-social-link a.btn-block + .login-pf-social-link a.btn-block {
+  margin-top: 5px;
+}
+input[type="submit"].login-pf-social-link a.btn-block,
+input[type="reset"].login-pf-social-link a.btn-block,
+input[type="button"].login-pf-social-link a.btn-block {
+  width: 100%;
+}


### PR DESCRIPTION
Swapped identity provider panel with local login. Added CSS rules to show identity provider login buttons as primary when available, and remove primary colour from "Login" button when identity providers are shown.