### PR TITLE
Support #20851 - Use service account to communicate with Keycloak

### DIFF
--- a/keycloak-dina-starter-realm.json
+++ b/keycloak-dina-starter-realm.json
@@ -14,6 +14,97 @@
   "sslRequired": "none",
   "clients": [
     {
+      "id": "96351fd7-c6bb-43c3-86cc-f13411f42505",
+      "clientId": "user-svc",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "120c0b7a-5ed2-4295-9a31-29c2fcbc714f",
+      "redirectUris": [
+        "*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.force.post.binding": "false",
+        "saml.multivalued.roles": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "8a04dc2c-bcf6-47ef-be99-b5fd1ce791c3",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "ea8dd46b-3107-415c-8faa-56f3c888f706",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "50fe231a-6662-4952-82be-35894897b887",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "roles"
+      ],
+      "optionalClientScopes": [
+        "offline_access"
+      ]
+    },
+    {
       "id": "fe3ef8c1-e615-4528-960b-e86b3102c7c0",
       "clientId": "objectstore",
       "enabled": true,
@@ -71,32 +162,11 @@
       },
       {
         "id": "90bc503d-ab0c-40a5-a0de-eedba9d09fc8",
-        "name": "admin",
-        "composite": true,
-        "composites": {
-          "client": {
-            "realm-management": [
-              "view-users",
-              "manage-users",
-              "query-groups",
-              "query-users"
-            ]
-          }
-        }
+        "name": "admin"
       },
       {
         "id": "62f69b76-740e-42f2-ba99-8adf42d8edd4",
-        "name": "collection-manager",
-        "composites": {
-          "client": {
-            "realm-management": [
-              "view-users",
-              "manage-users",
-              "query-groups",
-              "query-users"
-            ]
-          }
-        }
+        "name": "collection-manager"
       },
       {
         "id": "bf8685f9-8a74-40f2-a4bc-746f239e230c",
@@ -891,6 +961,30 @@
       "attributes": {
         "agentId": "34e1de96-cc79-4ce1-8cf6-d0be70ec7bed"
       }
+    },
+    {
+      "username": "service-account-user-svc",
+      "enabled": true,
+      "serviceAccountClientId": "user-svc",
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "user",
+        "uma_authorization",
+        "offline_access"
+      ],
+      "clientRoles": {
+        "realm-management": [
+          "view-users",
+          "manage-users"
+        ],
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups": []
     }
   ]
 }


### PR DESCRIPTION
Updated Keycloak realm definition:
- Added user-svc Keycloak client and service account
- Removed realm-management composite roles from all DINA roles; they are unnecessary when using the service account