### PR TITLE
Support #25465 - Update local deployment to use es_init_container:0.6

### DIFF
--- a/.env
+++ b/.env
@@ -46,7 +46,14 @@ SEQDB_MIGRATION_USER_PW=museqdb123
 SEQDB_WEB_USER=web_user_seqdb
 SEQDB_WEB_USER_PW=wuseqdb321
 
+# Elastic Search Variables
 ELASTIC_SERVER_URL=http://elasticsearch-dina:9200
 INDEX_CREATE_CMD=./create-index.sh
+
 DINA_AGENT_INDEX_NAME=dina_agent_index
 DINA_MATERIAL_SAMPLE_INDEX_NAME=dina_material_sample_index
+DINA_STORAGE_INDEX_NAME=dina_storage_index
+
+DINA_AGENT_INDEX_SETTINGS_FILE=/usr/share/elastic-configurator/settings/agent-index/dina_agent_index_settings.json
+DINA_MATERIAL_SAMPLE_INDEX_SETTINGS_FILE=/usr/share/elastic-configurator/settings/collection-index/dina_material_sample_index_settings.json
+DINA_STORAGE_INDEX_SETTINGS_FILE=/usr/share/elastic-configurator/settings/storage-index/dina_storage_index_settings.json

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -193,15 +193,18 @@ services:
 
   # Check the status of elasticsearch and configure indices if not already present.
   elastic-configurator:
-    image: aafcbicoe/es-init-container:0.5
+    image: aafcbicoe/es-init-container:0.6
     profiles: ["search_api"]
     environment:
       ELASTIC_SERVER_URL: $ELASTIC_SERVER_URL
       INDEX_CREATE_CMD: $INDEX_CREATE_CMD
+      DINA_INDEX_DECLARATIONS: AGENT MATERIAL_SAMPLE STORAGE
       DINA_AGENT_INDEX_NAME: $DINA_AGENT_INDEX_NAME
-      DINA_AGENT_INDEX_SETTINGS_FILE: /usr/share/elastic-configurator/settings/agent-index/dina_agent_index_settings.json
+      DINA_AGENT_INDEX_SETTINGS_FILE: $DINA_AGENT_INDEX_SETTINGS_FILE
       DINA_MATERIAL_SAMPLE_INDEX_NAME: $DINA_MATERIAL_SAMPLE_INDEX_NAME
-      DINA_MATERIAL_SAMPLE_INDEX_SETTINGS_FILE: /usr/share/elastic-configurator-settings/collection-index/dina_material_sample_index_settings.json
+      DINA_MATERIAL_SAMPLE_INDEX_SETTINGS_FILE: $DINA_MATERIAL_SAMPLE_INDEX_SETTINGS_FILE
+      DINA_STORAGE_INDEX_NAME: $DINA_STORAGE_INDEX_NAME
+      DINA_STORAGE_INDEX_SETTINGS_FILE: $DINA_STORAGE_INDEX_SETTINGS_FILE
     volumes:
       - ./elastic-configurator-settings:/usr/share/elastic-configurator/settings
     depends_on:
@@ -220,15 +223,16 @@ services:
       - "traefik.http.routers.searchws.rule=Host(`${API_HOSTNAME}`) && PathPrefix(`${SEARCH_API_PREFIX}/`)"
 
   search-cli:
-    image: aafcbicoe/dina-search-cli:0.5
+    image: aafcbicoe/dina-search-cli:0.6
     profiles: ["search_api"]
     environment:
       keycloak.openid_auth_server: http://${KEYCLOAK_HOSTNAME}:${KEYCLOAK_PORT}/auth/realms/dina/protocol/openid-connect/token
       ELASTICSEARCH_URL: elasticsearch-dina
-      MATERIAL_SAMPLE_URL: http://api.dina.local/collection/api/v1/material-sample
-      METADATA_URL: http://api.dina.local/objectstore/api/v1/metadata
-      ORGANIZATION_URL: http://api.dina.local/agent/api/v1/organization
-      PERSON_URL: http://api.dina.local/agent/api/v1/person
+      MATERIAL_SAMPLE_URL: http://${API_HOSTNAME}/collection/api/v1/material-sample
+      METADATA_URL: http://${API_HOSTNAME}/objectstore/api/v1/metadata
+      ORGANIZATION_URL: http://${API_HOSTNAME}/agent/api/v1/organization
+      PERSON_URL: http://${API_HOSTNAME}/agent/api/v1/person
+      STORAGE_UNIT_URL: http://${API_HOSTNAME}/collection/api/v1/storage-unit
       RABBITMQ_HOSTNAME: rabbitmq-dina
       IS_MESSAGE_CONSUMER: "true"
       IS_MESSAGE_PRODUCER: "true"


### PR DESCRIPTION
https://redmine.biodiversity.agr.gc.ca/issues/25465

- Updated the elastic configuration and search CLI to 0.6.
- Added the missing enviroment variables.
- Search CLI now uses the API_HOST name env instead of hardcoded values.