### PR TITLE
Support #35958 - Add message producer support to SeqDB API

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -440,6 +440,11 @@ services:
       spring:
         datasource:
           url: jdbc:postgresql://{{ .Values.global.environment.config.dina_db.service }}/seqdb?currentSchema=seqdb
+      rabbitmq:
+        host: "{{ .Values.global.environment.config.rabbitmq.service }}"
+      dina:
+        messaging:
+          isProducer: true
   rabbitmq:
     image: rabbitmq:3.9.29-management-alpine
 

--- a/message-producing-override/docker-compose.override.messageProducer.yml
+++ b/message-producing-override/docker-compose.override.messageProducer.yml
@@ -15,6 +15,13 @@ services:
     networks:
       - dina_rabbitmq_net
 
+  seqdb-api:
+    environment:
+      dina.messaging.isProducer: "true"
+      rabbitmq.host: rabbitmq-dina
+    networks:
+      - dina_rabbitmq_net
+
   loan-transaction-api:
     environment:
       dina.messaging.isProducer: "true"


### PR DESCRIPTION
- Added helm support for seqdb-api is producer environment variable.
- Added to the docker message producer override.