### PR TITLE
38563 unified image values

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -4,3 +4,27 @@
 {{ printf "%.0f" $xmxValueMB }}
 {{- end -}}
 
+{{/*
+Construct the full image name.
+Usage: {{ include "dina-helm.build-image-name" .Values.agentapi }}
+*/}}
+{{- define "dina-helm.build-image-name" -}}
+{{- $registry := .registry -}}
+{{- $repository := .repository -}}
+{{- $tag := .tag | toString -}}
+
+{{- /* Validation: Repository and Tag are required */ -}}
+{{- if not $repository -}}
+  {{- fail "An image repository is required" -}}
+{{- end -}}
+{{- if not $tag -}}
+  {{- fail "An image tag is required" -}}
+{{- end -}}
+
+{{- /* Logic: If registry exists, add it with a trailing slash */ -}}
+{{- if $registry -}}
+  {{- printf "%s/%s:%s" $registry $repository $tag -}}
+{{- else -}}
+  {{- printf "%s:%s" $repository $tag -}}
+{{- end -}}
+{{- end -}}

--- a/helm/templates/_nsswrapper-postgres.tpl
+++ b/helm/templates/_nsswrapper-postgres.tpl
@@ -1,7 +1,6 @@
 {{- define "nss-wrapper-init-postgres" -}}
 initContainers:
   - name: nss-wrapper-init
-    imagePullPolicy: IfNotPresent
     command:
       - bash
       - -cx

--- a/helm/templates/deployments/agent-api.yaml
+++ b/helm/templates/deployments/agent-api.yaml
@@ -23,7 +23,10 @@ spec:
     spec:
       initContainers:
         - name: check-db
-          image: {{ .Values.services.initdb.image }}
+          {{- with .Values.initdb.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           command:
             - sh
             - -c
@@ -36,7 +39,10 @@ spec:
               memory: {{ .Values.resources.initcontainers.limits.memory }} 
               cpu: {{ .Values.resources.initcontainers.limits.cpu }}
         - name: init-db
-          image: {{ .Values.services.initdb.image }}
+          {{- with .Values.initdb.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           env:
           - name: POSTGRES_DB
             value: {{ tpl .Values.services.initdb.environment.POSTGRES_DB . }}
@@ -86,7 +92,10 @@ spec:
               cpu: {{ .Values.resources.initcontainers.limits.cpu }}
       containers:
         - name: agent-api
-          image: {{ .Values.services.agentapi.image }}
+          {{- with .Values.agentapi.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           {{- if .Values.messageProducerOverride.enabled }}
           envFrom:
             - configMapRef:

--- a/helm/templates/deployments/collection-api.yaml
+++ b/helm/templates/deployments/collection-api.yaml
@@ -23,7 +23,10 @@ spec:
     spec:
       initContainers:
         - name: check-db
-          image: {{ .Values.services.initdb.image }}
+          {{- with .Values.initdb.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           command:
             - sh
             - -c
@@ -36,7 +39,10 @@ spec:
               memory: {{ .Values.resources.initcontainers.limits.memory }} 
               cpu: {{ .Values.resources.initcontainers.limits.cpu }}
         - name: init-db
-          image: {{ .Values.services.initdb.image }}
+          {{- with .Values.initdb.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           env:
           - name: POSTGRES_DB
             value: {{ tpl .Values.services.initdb.environment.POSTGRES_DB . }}
@@ -88,8 +94,10 @@ spec:
               cpu: {{ .Values.resources.initcontainers.limits.cpu }}
       containers:
         - name: collection-api
-          image: {{ .Values.services.collectionapi.image }}
-          imagePullPolicy: {{ .Values.services.keycloak.pullPolicy }}
+          {{- with .Values.collectionapi.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           {{- if .Values.messageProducerOverride.enabled }}
           envFrom:
             - configMapRef:

--- a/helm/templates/deployments/dina-db.yaml
+++ b/helm/templates/deployments/dina-db.yaml
@@ -23,7 +23,10 @@ spec:
       terminationGracePeriodSeconds: 10
       {{- if .Values.global.environment.isOpenShift }}
       {{- include "nss-wrapper-init-postgres" . | nindent 6 }}
-          image: {{ .Values.services.dinadb.image }}
+          {{- with .Values.dinadb.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
       {{- end}}
       containers:
         - env:
@@ -43,7 +46,10 @@ spec:
             {{- if .Values.global.environment.isOpenShift }}
               {{- include "nss-wrapper-env" . | nindent 10 }}
             {{- end}}
-          image: {{ .Values.services.dinadb.image }}
+          {{- with .Values.dinadb.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           volumeMounts:
             - name: postgres-data
               mountPath: /var/lib/postgresql/

--- a/helm/templates/deployments/dina-export-api.yaml
+++ b/helm/templates/deployments/dina-export-api.yaml
@@ -23,7 +23,10 @@ spec:
     spec:
       initContainers:
         - name: check-db
-          image: {{ .Values.services.initdb.image }}
+          {{- with .Values.initdb.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           command:
             - sh
             - -c
@@ -36,7 +39,10 @@ spec:
               memory: {{ .Values.resources.initcontainers.limits.memory }} 
               cpu: {{ .Values.resources.initcontainers.limits.cpu }}
         - name: init-db
-          image: {{ .Values.services.initdb.image }}
+          {{- with .Values.initdb.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           env:
           - name: POSTGRES_DB
             value: {{ tpl .Values.services.initdb.environment.POSTGRES_DB . }}
@@ -86,7 +92,10 @@ spec:
               cpu: {{ .Values.resources.initcontainers.limits.cpu }}
       containers:
         - name: dina-export-api
-          image: {{ .Values.services.dinaexportapi.image }}
+          {{- with .Values.dinaexportapi.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           {{- if .Values.messageProducerOverride.enabled }}
           envFrom:
             - configMapRef:

--- a/helm/templates/deployments/dina-ui.yaml
+++ b/helm/templates/deployments/dina-ui.yaml
@@ -23,7 +23,10 @@ spec:
     spec:
       containers:
         - name: dina-ui
-          image: {{ .Values.services.dinaui.image }}
+          {{- with .Values.dinaui.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           env:
             - name: KEYCLOAK_CLIENTID
               value: {{ tpl .Values.services.dinaui.environment.KEYCLOAK_CLIENTID . }}

--- a/helm/templates/deployments/dina-user-api.yaml
+++ b/helm/templates/deployments/dina-user-api.yaml
@@ -23,7 +23,10 @@ spec:
     spec:
       initContainers:
         - name: check-db
-          image: {{ .Values.services.initdb.image }}
+          {{- with .Values.initdb.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           command:
             - sh
             - -c
@@ -36,7 +39,10 @@ spec:
               memory: {{ .Values.resources.initcontainers.limits.memory }} 
               cpu: {{ .Values.resources.initcontainers.limits.cpu }}
         - name: init-db
-          image: {{ .Values.services.initdb.image }}
+          {{- with .Values.initdb.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           env:
           - name: POSTGRES_DB
             value: {{ tpl .Values.services.initdb.environment.POSTGRES_DB . }}
@@ -86,7 +92,10 @@ spec:
               cpu: {{ .Values.resources.initcontainers.limits.cpu }}
       containers:
         - name: dina-user-api
-          image: {{ .Values.services.dinauserapi.image }}
+          {{- with .Values.dinauserapi.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           {{- if .Values.messageProducerOverride.enabled }}
           envFrom:
             - configMapRef:

--- a/helm/templates/deployments/elasticsearch-dina.yaml
+++ b/helm/templates/deployments/elasticsearch-dina.yaml
@@ -17,7 +17,10 @@ spec:
     spec:
       containers:
         - name: elasticsearch-dina
-          image: {{ .Values.services.elasticsearchdina.image }}
+          {{- with .Values.elasticsearchdina.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           command:
           - /bin/bash
           - -ce

--- a/helm/templates/deployments/keycloak.yaml
+++ b/helm/templates/deployments/keycloak.yaml
@@ -22,7 +22,10 @@ spec:
     spec:
       initContainers:
         - name: check-db
-          image: {{ .Values.services.initdb.image }}
+          {{- with .Values.initdb.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           command:
             - sh
             - -c
@@ -35,7 +38,10 @@ spec:
               memory: {{ .Values.resources.initcontainers.limits.memory }} 
               cpu: {{ .Values.resources.initcontainers.limits.cpu }}
         - name: init-db
-          image: {{ .Values.services.initdb.image }}
+          {{- with .Values.initdb.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           resources:
             requests:
               memory: {{ .Values.resources.initcontainers.requests.memory }}
@@ -74,6 +80,10 @@ spec:
             {{- end }}
       containers:
         - name: keycloak
+          {{- with .Values.keycloak.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           command:
           - /bin/bash
           - -ce
@@ -81,8 +91,6 @@ spec:
           - |
             /opt/keycloak/bin/kc.sh build --db=postgres --http-relative-path=/auth
             /opt/keycloak/bin/kc.sh start --import-realm --optimized
-          image: {{ .Values.services.keycloak.image }}
-          imagePullPolicy: {{ .Values.services.keycloak.pullPolicy }}
           env:
             - name: KC_DB_PASSWORD
               {{- if not .Values.global.environment.config.keycloak.db_password }}

--- a/helm/templates/deployments/loan-transaction-api.yaml
+++ b/helm/templates/deployments/loan-transaction-api.yaml
@@ -23,7 +23,10 @@ spec:
     spec:
       initContainers:
         - name: check-db
-          image: {{ .Values.services.initdb.image }}
+          {{- with .Values.initdb.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           command:
             - sh
             - -c
@@ -36,7 +39,10 @@ spec:
               memory: {{ .Values.resources.initcontainers.limits.memory }} 
               cpu: {{ .Values.resources.initcontainers.limits.cpu }}
         - name: init-db
-          image: {{ .Values.services.initdb.image }}
+          {{- with .Values.initdb.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           env:
           - name: POSTGRES_DB
             value: {{ tpl .Values.services.initdb.environment.POSTGRES_DB . }}
@@ -86,7 +92,10 @@ spec:
               cpu: {{ .Values.resources.initcontainers.limits.cpu }}
       containers:
         - name: loan-transaction-api
-          image: {{ .Values.services.loantransactionapi.image }}
+          {{- with .Values.loantransactionapi.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           {{- if .Values.messageProducerOverride.enabled }}
           envFrom:
             - configMapRef:

--- a/helm/templates/deployments/objectstore-api.yaml
+++ b/helm/templates/deployments/objectstore-api.yaml
@@ -40,7 +40,10 @@ spec:
     spec:
       initContainers:
         - name: check-db
-          image: {{ .Values.services.initdb.image }}
+          {{- with .Values.initdb.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           command:
             - sh
             - -c
@@ -53,7 +56,10 @@ spec:
               memory: {{ .Values.resources.initcontainers.limits.memory }} 
               cpu: {{ .Values.resources.initcontainers.limits.cpu }}
         - name: init-db
-          image: {{ .Values.services.initdb.image }}
+          {{- with .Values.initdb.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           env:
           - name: POSTGRES_DB
             value: {{ tpl .Values.services.initdb.environment.POSTGRES_DB . }}
@@ -103,7 +109,10 @@ spec:
               cpu: {{ .Values.resources.initcontainers.limits.cpu }}
       containers:
         - name: object-store-api
-          image: {{ .Values.services.objectstoreapi.image }}
+          {{- with .Values.objectstoreapi.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           {{- if .Values.messageProducerOverride.enabled }}
           envFrom:
             - configMapRef:

--- a/helm/templates/deployments/rabbitmq.yaml
+++ b/helm/templates/deployments/rabbitmq.yaml
@@ -24,7 +24,10 @@ spec:
       hostname: rabbit-dina-node-1
       containers:
         - name: rabbitmq-dina
-          image: {{ .Values.services.rabbitmq.image }}
+          {{- with .Values.rabbitmq.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           ports:
             - name: producer-port
               containerPort: 5672

--- a/helm/templates/deployments/search-cli.yaml
+++ b/helm/templates/deployments/search-cli.yaml
@@ -23,7 +23,10 @@ spec:
     spec:
       initContainers:
         - name: elastic-configurator
-          image: {{ .Values.services.elasticconfigurator.image }}
+          {{- with .Values.elasticconfigurator.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           env:
             - name: ELASTIC_SERVER_URL
               value: {{ .Values.services.elasticconfigurator.environment.ELASTIC_SERVER_URL }}
@@ -86,7 +89,10 @@ spec:
               mountPath: /usr/share/elastic-configurator/certs
       containers:
         - name: search-cli
-          image: {{ .Values.services.searchcli.image }}
+          {{- with .Values.searchcli.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           env:
             - name: HTTP-CLIENT_OPENIDCONNECTBASEURL
               value: {{ tpl .Values.services.searchcli.environment.http_client.openid_connect_base_url . }}

--- a/helm/templates/deployments/search-ws.yaml
+++ b/helm/templates/deployments/search-ws.yaml
@@ -23,7 +23,10 @@ spec:
     spec:
       containers:
         - name: search-ws
-          image: {{ .Values.services.searchws.image }}
+          {{- with .Values.searchws.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           env:
             - name: KEYCLOAK_ENABLED
               value: {{ .Values.global.environment.keycloak.enabled | quote }}

--- a/helm/templates/deployments/seqdb-api.yaml
+++ b/helm/templates/deployments/seqdb-api.yaml
@@ -23,7 +23,10 @@ spec:
     spec:
       initContainers:
         - name: check-db
-          image: {{ .Values.services.initdb.image }}
+          {{- with .Values.initdb.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           command:
             - sh
             - -c
@@ -36,7 +39,10 @@ spec:
               memory: {{ .Values.resources.initcontainers.limits.memory }} 
               cpu: {{ .Values.resources.initcontainers.limits.cpu }}
         - name: init-db
-          image: {{ .Values.services.initdb.image }}
+          {{- with .Values.initdb.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           env:
             - name: POSTGRES_DB
               value: {{ tpl .Values.services.initdb.environment.POSTGRES_DB . }}
@@ -88,7 +94,10 @@ spec:
               cpu: {{ .Values.resources.initcontainers.limits.cpu }}
       containers:
         - name: seqdb-api
-          image: {{ .Values.services.seqdbapi.image }}
+          {{- with .Values.seqdbapi.image }}
+          image: {{ include "dina-helm.build-image-name" . | quote }}
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" | quote }}
+          {{- end }}
           env:
             - name: KEYCLOAK_ENABLED
               value: {{ .Values.global.environment.keycloak.enabled | quote }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -11,37 +11,37 @@ agentapi:
   image:
     registry: docker.io
     repository: aafcbicoe/agent-api
-    tag: 0.33
+    tag: 0.34
     pullPolicy: IfNotPresent
 collectionapi:
   image:
     registry: docker.io
     repository: aafcbicoe/natural-history-collection-api
-    tag: 0.121
+    tag: 0.122.1
     pullPolicy: IfNotPresent
 dinaexportapi:
   image:
     registry: docker.io
     repository: aafcbicoe/dina-export-api
-    tag: 0.23
+    tag: 0.24
     pullPolicy: IfNotPresent
 dinaui:
   image:
     registry: docker.io
     repository: aafcbicoe/dina-ui
-    tag: 0.219.0
+    tag: 0.221.0
     pullPolicy: IfNotPresent
 dinauserapi:
   image:
     registry: docker.io
     repository: aafcbicoe/dina-user-api
-    tag: 0.27
+    tag: 0.28
     pullPolicy: IfNotPresent
 loantransactionapi:
   image:
     registry: docker.io
     repository: aafcbicoe/loan-transaction-api
-    tag: 0.14
+    tag: 0.15
     pullPolicy: IfNotPresent
 objectstoreapi:
   image:
@@ -77,19 +77,19 @@ searchcli:
   image:
     registry: docker.io
     repository: aafcbicoe/dina-search-cli
-    tag: 0.54
+    tag: 0.55
     pullPolicy: IfNotPresent
 searchws:
   image:
     registry: docker.io
     repository: aafcbicoe/dina-search-ws
-    tag: 0.54
+    tag: 0.55
     pullPolicy: IfNotPresent
 seqdbapi:
   image:
     registry: docker.io
     repository: aafcbicoe/seqdb-api
-    tag: 2.25.0
+    tag: 2.26.0
     pullPolicy: IfNotPresent
 rabbitmq:
   image:
@@ -337,8 +337,6 @@ services:
             password: "{{ .Values.global.environment.config.seqdb_api.liquibase_password }}"
         PG_EXTENSION_seqdb: pgcrypto
   agentapi:
-    image: aafcbicoe/agent-api:0.34
-    pullPolicy: IfNotPresent
     environment:
       rabbitmq:
         host: "{{ .Values.global.environment.config.rabbitmq.service }}"
@@ -349,8 +347,6 @@ services:
         datasource:
           url: jdbc:postgresql://{{ .Values.global.environment.config.dina_db.service }}/agent?currentSchema=agent
   collectionapi:
-    image: aafcbicoe/natural-history-collection-api:0.122.1
-    pullPolicy: IfNotPresent
     config:
       java_opts: "-XX:MaxRAMPercentage=80.0 -XX:+ExitOnOutOfMemoryError"
     environment:
@@ -365,8 +361,6 @@ services:
       actuator:
         allowedIP: prometheus
   dinaexportapi:
-    image: aafcbicoe/dina-export-api:0.24
-    pullPolicy: IfNotPresent
     environment:
       spring:
         datasource:
@@ -399,7 +393,6 @@ services:
         username: elastic
         certPath: /app/certs/ca/ca.crt
   dinaui:
-    image: aafcbicoe/dina-ui:0.221.0
     environment:
       KEYCLOAK_CLIENTID: "{{ .Values.global.environment.keycloak.client_id }}"
       KEYCLOAK_REALM: "{{ .Values.global.environment.keycloak.realm }}"
@@ -416,7 +409,6 @@ services:
       INSTANCE_NAME: "{{ .Values.global.environment.config.dina_ui.instance_name }}"
       SUPPORTED_LANGUAGES_ISO: "{{ .Values.global.environment.config.dina_ui.supported_languages_iso }}"
   dinauserapi:
-    image: aafcbicoe/dina-user-api:0.28
     environment:
       spring:
         datasource:
@@ -431,7 +423,6 @@ services:
         username: "{{ .Values.global.environment.config.rabbitmq.username }}"
         password: "{{ .Values.global.environment.config.rabbitmq.password }}"
   loantransactionapi:
-    image: aafcbicoe/loan-transaction-api:0.15
     environment:
       rabbitmq:
         host: "{{ .Values.global.environment.config.rabbitmq.service }}"
@@ -542,7 +533,6 @@ services:
       DB_USER: "{{ .Values.global.environment.config.keycloak.db_user }}"
       DB_PASSWORD: "{{ .Values.global.environment.config.keycloak.db_password }}"
   searchcli:
-    image: aafcbicoe/dina-search-cli:0.55
     environment:
       http_client:
         openid_connect_base_url: "{{ tpl .Values.global.environment.keycloak.auth_server_url_internal . }}/realms/dina/protocol/openid-connect/"
@@ -562,14 +552,12 @@ services:
       IS_MESSAGE_CONSUMER: true
       IS_MESSAGE_PRODUCER: true
   searchws:
-    image: aafcbicoe/dina-search-ws:0.55
     environment:
       elasticsearch:
         host: "{{ .Values.global.environment.config.elasticsearch.service }}"
         username: elastic
         certPath: /app/certs/ca/ca.crt
   seqdbapi:
-    image: aafcbicoe/seqdb-api:2.26.0
     config:
       java_opts: "-XX:MaxRAMPercentage=80.0 -XX:+ExitOnOutOfMemoryError"
     environment:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -95,7 +95,7 @@ rabbitmq:
   image:
     registry: docker.io
     repository: rabbitmq
-    tag: 3.9.29-management-alpine
+    tag: 4.3.1-management-alpine
     pullPolicy: IfNotPresent
 
 profiles:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -569,7 +569,6 @@ services:
         messaging:
           isProducer: true
   rabbitmq:
-    image: rabbitmq:4.3.1-management-alpine
     config:
       enabledPlugins: 
         - rabbitmq_shovel

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,6 +1,103 @@
 # Default values for dina-helm-test.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+initdb:
+  image:
+    registry: docker.io
+    repository: aafcbicoe/dina-db-init-container
+    tag: 0.8
+    pullPolicy: IfNotPresent
+agentapi:
+  image:
+    registry: docker.io
+    repository: aafcbicoe/agent-api
+    tag: 0.33
+    pullPolicy: IfNotPresent
+collectionapi:
+  image:
+    registry: docker.io
+    repository: aafcbicoe/natural-history-collection-api
+    tag: 0.121
+    pullPolicy: IfNotPresent
+dinaexportapi:
+  image:
+    registry: docker.io
+    repository: aafcbicoe/dina-export-api
+    tag: 0.23
+    pullPolicy: IfNotPresent
+dinaui:
+  image:
+    registry: docker.io
+    repository: aafcbicoe/dina-ui
+    tag: 0.219.0
+    pullPolicy: IfNotPresent
+dinauserapi:
+  image:
+    registry: docker.io
+    repository: aafcbicoe/dina-user-api
+    tag: 0.27
+    pullPolicy: IfNotPresent
+loantransactionapi:
+  image:
+    registry: docker.io
+    repository: aafcbicoe/loan-transaction-api
+    tag: 0.14
+    pullPolicy: IfNotPresent
+objectstoreapi:
+  image:
+    registry: docker.io
+    repository: aafcbicoe/object-store-api
+    tag: 1.34
+    pullPolicy: IfNotPresent
+keycloak:
+  image:
+    registry: quay.io
+    repository: keycloak/keycloak
+    tag: 24.0.5
+    pullPolicy: IfNotPresent
+elasticsearchdina:
+  image:
+    registry: docker.elastic.co
+    repository: elasticsearch/elasticsearch
+    tag: 8.11.1
+    pullPolicy: IfNotPresent
+elasticconfigurator:
+  image:
+    registry: docker.io
+    repository: aafcbicoe/es-init-container
+    tag: 0.16
+    pullPolicy: IfNotPresent
+dinadb:
+  image:
+    registry: docker.io
+    repository: postgis/postgis
+    tag: 13-3.2
+    pullPolicy: IfNotPresent
+searchcli:
+  image:
+    registry: docker.io
+    repository: aafcbicoe/dina-search-cli
+    tag: 0.54
+    pullPolicy: IfNotPresent
+searchws:
+  image:
+    registry: docker.io
+    repository: aafcbicoe/dina-search-ws
+    tag: 0.54
+    pullPolicy: IfNotPresent
+seqdbapi:
+  image:
+    registry: docker.io
+    repository: aafcbicoe/seqdb-api
+    tag: 2.25.0
+    pullPolicy: IfNotPresent
+rabbitmq:
+  image:
+    registry: docker.io
+    repository: rabbitmq
+    tag: 3.9.29-management-alpine
+    pullPolicy: IfNotPresent
+
 profiles:
   agent_api:
     enabled: true
@@ -153,8 +250,6 @@ global:
     elasticsearch: elasticsearch.dina.localhost
 services:
   initdb:
-    image: aafcbicoe/dina-db-init-container:0.8
-    pullPolicy: IfNotPresent
     environment:
       # Database Connection Environment Variables:
       POSTGRES_DB: "{{ .Values.global.environment.config.dina_db.db_name }}"
@@ -241,8 +336,6 @@ services:
             password: "{{ .Values.global.environment.config.seqdb_api.liquibase_password }}"
         PG_EXTENSION_seqdb: pgcrypto
   agentapi:
-    image: aafcbicoe/agent-api:0.33
-    pullPolicy: IfNotPresent
     environment:
       rabbitmq:
         host: "{{ .Values.global.environment.config.rabbitmq.service }}"
@@ -253,8 +346,6 @@ services:
         datasource:
           url: jdbc:postgresql://{{ .Values.global.environment.config.dina_db.service }}/agent?currentSchema=agent
   collectionapi:
-    image: aafcbicoe/natural-history-collection-api:0.121
-    pullPolicy: IfNotPresent
     config:
       java_opts: "-XX:MaxRAMPercentage=80.0 -XX:+ExitOnOutOfMemoryError"
     environment:
@@ -269,8 +360,6 @@ services:
       actuator:
         allowedIP: prometheus
   dinaexportapi:
-    image: aafcbicoe/dina-export-api:0.23
-    pullPolicy: IfNotPresent
     environment:
       spring:
         datasource:
@@ -303,7 +392,6 @@ services:
         username: elastic
         certPath: /app/certs/ca/ca.crt
   dinaui:
-    image: aafcbicoe/dina-ui:0.219.0
     environment:
       KEYCLOAK_CLIENTID: "{{ .Values.global.environment.keycloak.client_id }}"
       KEYCLOAK_REALM: "{{ .Values.global.environment.keycloak.realm }}"
@@ -320,7 +408,6 @@ services:
       INSTANCE_NAME: "{{ .Values.global.environment.config.dina_ui.instance_name }}"
       SUPPORTED_LANGUAGES_ISO: "{{ .Values.global.environment.config.dina_ui.supported_languages_iso }}"
   dinauserapi:
-    image: aafcbicoe/dina-user-api:0.27
     environment:
       spring:
         datasource:
@@ -335,7 +422,6 @@ services:
         username: "{{ .Values.global.environment.config.rabbitmq.username }}"
         password: "{{ .Values.global.environment.config.rabbitmq.password }}"
   loantransactionapi:
-    image: aafcbicoe/loan-transaction-api:0.14
     environment:
       rabbitmq:
         host: "{{ .Values.global.environment.config.rabbitmq.service }}"
@@ -346,7 +432,6 @@ services:
         datasource:
           url: jdbc:postgresql://{{ .Values.global.environment.config.dina_db.service }}/loan_transaction?currentSchema=loan_transaction
   objectstoreapi:
-    image: aafcbicoe/object-store-api:1.34
     config:
       java_opts: "-XX:MaxRAMPercentage=80.0 -XX:+ExitOnOutOfMemoryError"
     environment:
@@ -377,8 +462,6 @@ services:
       volumeName: object-store-volume
 
   keycloak:
-    pullPolicy: IfNotPresent
-    image: "quay.io/keycloak/keycloak:24.0.5"
     environment:
       KC_DB_PASSWORD: "{{ .Values.global.environment.config.keycloak.db_password }}"
       KEYCLOAK_ADMIN: "{{ .Values.global.environment.config.keycloak.keycloak_admin }}"
@@ -390,7 +473,6 @@ services:
       KC_HOSTNAME_ADMIN: "{{ .Values.global.endpoints.keycloak }}"
       KC_PROXY: edge
   elasticsearchdina:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.1
     environment:
       xpack:
         security:
@@ -424,7 +506,6 @@ services:
     cap_add:
       - IPC_LOCK
   elasticconfigurator:
-    image: aafcbicoe/es-init-container:0.16
     environment:
       ELASTIC_SERVER_URL: https://elasticsearch-service:9200
       ES_CA_FILE: /usr/share/elastic-configurator/certs/ca/ca.crt
@@ -446,13 +527,11 @@ services:
       DINA_COLLECTING_EVENT_INDEX_NAME: dina_collecting_event_index
       DINA_COLLECTING_EVENT_INDEX_SETTINGS_FILE: /usr/share/elastic-configurator/settings/dina_collecting_event_index_settings.json
   dinadb:
-    image: "postgis/postgis:13-3.2"
     environment:
       POSTGRES_DB: "{{ .Values.global.environment.config.keycloak.db_name }}"
       DB_USER: "{{ .Values.global.environment.config.keycloak.db_user }}"
       DB_PASSWORD: "{{ .Values.global.environment.config.keycloak.db_password }}"
   searchcli:
-    image: aafcbicoe/dina-search-cli:0.54
     environment:
       http_client:
         openid_connect_base_url: "{{ tpl .Values.global.environment.keycloak.auth_server_url_internal . }}/realms/dina/protocol/openid-connect/"
@@ -472,14 +551,12 @@ services:
       IS_MESSAGE_CONSUMER: true
       IS_MESSAGE_PRODUCER: true
   searchws:
-    image: aafcbicoe/dina-search-ws:0.54
     environment:
       elasticsearch:
         host: "{{ .Values.global.environment.config.elasticsearch.service }}"
         username: elastic
         certPath: /app/certs/ca/ca.crt
   seqdbapi:
-    image: aafcbicoe/seqdb-api:2.25.0
     config:
       java_opts: "-XX:MaxRAMPercentage=80.0 -XX:+ExitOnOutOfMemoryError"
     environment:


### PR DESCRIPTION
- Moves image names to a single place in `values.yaml`
- Separates image names into `registry`, `repository`, `tag` and `pullPolicy` key-value pairs to match best practices from popular open source helm charts
- Updates deployments to reference the new location for image names
  - A new template function  `dina-helm.build-image-name` is added to 
- Removes old values for image names in `values.yaml`

Tests:
- Compared diff of `helm template dina-helm .` before and after changes to confirm no adverse effects from changes
  - Also compared with `--set global.environment.isOpenShift=true` flag
- Helm chart still runs fine on this branch