### PR TITLE
 38576 Updating auto.secrets.yaml to loop over values

### DIFF
--- a/helm/templates/secrets/auto.secrets.yaml
+++ b/helm/templates/secrets/auto.secrets.yaml
@@ -1,305 +1,41 @@
-{{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "dina-db-secret") }}
-{{- if and (not .Values.global.environment.config.dina_db.db_password) (not $secretObj) }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: "dina-db-secret"
-  annotations:
-    "helm.sh/resource-policy": "keep"
-type: Opaque
-data:
-  {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "dina-db-secret") | default dict }}
-  {{- $secretData := (get $secretObj "data") | default dict }}
-  {{- $dbSecret := (get $secretData "dina-db-secret") | default (randAlphaNum 32 | b64enc) }}
-  password: {{ $dbSecret | quote }}
-{{- else }}
-{{- end }}
+{{- /* Define the list of secrets and their corresponding existing value settings */ -}}
+{{- $secretConfigs := list
+  (dict "name" "dina-db-secret" "val" .Values.global.environment.config.dina_db.db_password)
+  (dict "name" "keycloak-db-secret" "val" .Values.global.environment.config.keycloak.db_password)
+  (dict "name" "keycloak-admin-secret" "val" .Values.global.environment.config.keycloak.keycloak_admin_password)
+  (dict "name" "collection-datasource-secret" "val" .Values.global.environment.config.collection_api.datasource_password)
+  (dict "name" "collection-liquibase-secret" "val" .Values.global.environment.config.collection_api.liquibase_password)
+  (dict "name" "objectstore-datasource-secret" "val" .Values.global.environment.config.objectstore_api.datasource_password)
+  (dict "name" "objectstore-liquibase-secret" "val" .Values.global.environment.config.objectstore_api.liquibase_password)
+  (dict "name" "dinauserapi-liquibase-secret" "val" .Values.global.environment.config.dina_user_api.liquibase_password)
+  (dict "name" "dinauserapi-datasource-secret" "val" .Values.global.environment.config.dina_user_api.datasource_password)
+  (dict "name" "loantransactionapi-datasource-secret" "val" .Values.global.environment.config.loan_transaction_api.datasource_password)
+  (dict "name" "loantransactionapi-liquibase-secret" "val" .Values.global.environment.config.loan_transaction_api.liquibase_password)
+  (dict "name" "agentapi-datasource-secret" "val" .Values.global.environment.config.agent_api.datasource_password)
+  (dict "name" "agentapi-liquibase-secret" "val" .Values.global.environment.config.agent_api.liquibase_password)
+  (dict "name" "dinaexportapi-datasource-secret" "val" .Values.global.environment.config.dina_export_api.datasource_password)
+  (dict "name" "dinaexportapi-liquibase-secret" "val" .Values.global.environment.config.dina_export_api.liquibase_password)
+  (dict "name" "seqdbapi-datasource-secret" "val" .Values.global.environment.config.seqdb_api.datasource_password)
+  (dict "name" "seqdbapi-liquibase-secret" "val" .Values.global.environment.config.seqdb_api.liquibase_password)
+  (dict "name" "elasticsearch-secret" "val" .Values.global.environment.config.elasticsearch.password)
+}}
+
+{{- $namespace := .Release.Namespace -}}
+
+{{- range $index, $secret := $secretConfigs }}
+{{- $existingSecret := (lookup "v1" "Secret" $namespace $secret.name) -}}
+{{- /* Only create the secret if the value isn't provided in helm values AND it doesn't already exist in the cluster */ -}}
+{{- if and (not $secret.val) (not $existingSecret) }}
 ---
-{{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "keycloak-db-secret") }}
-{{- if and (not .Values.global.environment.config.keycloak.db_password) (not $secretObj) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: "keycloak-db-secret"
+  name: {{ $secret.name | quote }}
   annotations:
     "helm.sh/resource-policy": "keep"
 type: Opaque
 data:
-  {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "keycloak-db-secret") | default dict }}
-  {{- $secretData := (get $secretObj "data") | default dict }}
-  {{- $dbSecret := (get $secretData "keycloak-db-secret") | default (randAlphaNum 32 | b64enc) }}
-  password: {{ $dbSecret | quote }}
-{{- else }}
+  {{- /* Note: Lookup returned nothing, generate new password */}}
+  password: {{ randAlphaNum 32 | b64enc | quote }}
 {{- end }}
----
-{{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "keycloak-admin-secret") }}
-{{- if and (not .Values.global.environment.config.keycloak.keycloak_admin_password) (not $secretObj) }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: "keycloak-admin-secret"
-  annotations:
-    "helm.sh/resource-policy": "keep"
-type: Opaque
-data:
-  {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "keycloak-admin-secret") | default dict }}
-  {{- $secretData := (get $secretObj "data") | default dict }}
-  {{- $dbSecret := (get $secretData "keycloak-admin-secret") | default (randAlphaNum 32 | b64enc) }}
-  password: {{ $dbSecret | quote }}
-{{- else }}
-{{- end }}
----
-{{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "collection-datasource-secret") }}
-{{- if and (not .Values.global.environment.config.collection_api.datasource_password) (not $secretObj) }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: "collection-datasource-secret"
-  annotations:
-    "helm.sh/resource-policy": "keep"
-type: Opaque
-data:
-  {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "collection-datasource-secret") | default dict }}
-  {{- $secretData := (get $secretObj "data") | default dict }}
-  {{- $dbSecret := (get $secretData "collection-datasource-secret") | default (randAlphaNum 32 | b64enc) }}
-  password: {{ $dbSecret | quote }}
-{{- else }}
-{{- end }}
----
-{{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "collection-liquibase-secret") }}
-{{- if and (not .Values.global.environment.config.collection_api.liquibase_password) (not $secretObj) }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: "collection-liquibase-secret"
-  annotations:
-    "helm.sh/resource-policy": "keep"
-type: Opaque
-data:
-  {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "collection-liquibase-secret") | default dict }}
-  {{- $secretData := (get $secretObj "data") | default dict }}
-  {{- $dbSecret := (get $secretData "collection-liquibase-secret") | default (randAlphaNum 32 | b64enc) }}
-  password: {{ $dbSecret | quote }}
-{{- else }}
-{{- end }}
----
-{{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "objectstore-datasource-secret") }}
-{{- if and (not .Values.global.environment.config.objectstore_api.datasource_password) (not $secretObj) }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: "objectstore-datasource-secret"
-  annotations:
-    "helm.sh/resource-policy": "keep"
-type: Opaque
-data:
-  {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "objectstore-datasource-secret") | default dict }}
-  {{- $secretData := (get $secretObj "data") | default dict }}
-  {{- $dbSecret := (get $secretData "objectstore-datasource-secret") | default (randAlphaNum 32 | b64enc) }}
-  password: {{ $dbSecret | quote }}
-{{- else }}
-{{- end }}
----
-{{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "objectstore-liquibase-secret") }}
-{{- if and (not .Values.global.environment.config.objectstore_api.liquibase_password) (not $secretObj) }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: "objectstore-liquibase-secret"
-  annotations:
-    "helm.sh/resource-policy": "keep"
-type: Opaque
-data:
-  {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "objectstore-liquibase-secret") | default dict }}
-  {{- $secretData := (get $secretObj "data") | default dict }}
-  {{- $dbSecret := (get $secretData "objectstore-liquibase-secret") | default (randAlphaNum 32 | b64enc) }}
-  password: {{ $dbSecret | quote }}
-{{- else }}
-{{- end }}
----
-{{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "dinauserapi-liquibase-secret") }}
-{{- if and (not .Values.global.environment.config.dina_user_api.liquibase_password) (not $secretObj) }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: "dinauserapi-liquibase-secret"
-  annotations:
-    "helm.sh/resource-policy": "keep"
-type: Opaque
-data:
-  {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "dinauserapi-liquibase-secret") | default dict }}
-  {{- $secretData := (get $secretObj "data") | default dict }}
-  {{- $dbSecret := (get $secretData "dinauserapi-liquibase-secret") | default (randAlphaNum 32 | b64enc) }}
-  password: {{ $dbSecret | quote }}
-{{- else }}
-{{- end }}
----
-{{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "dinauserapi-datasource-secret") }}
-{{- if and (not .Values.global.environment.config.dina_user_api.datasource_password) (not $secretObj) }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: "dinauserapi-datasource-secret"
-  annotations:
-    "helm.sh/resource-policy": "keep"
-type: Opaque
-data:
-  {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "dinauserapi-datasource-secret") | default dict }}
-  {{- $secretData := (get $secretObj "data") | default dict }}
-  {{- $dbSecret := (get $secretData "dinauserapi-datasource-secret") | default (randAlphaNum 32 | b64enc) }}
-  password: {{ $dbSecret | quote }}
-{{- else }}
-{{- end }}
----
-{{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "loantransactionapi-datasource-secret") }}
-{{- if and (not .Values.global.environment.config.loan_transaction_api.datasource_password) (not $secretObj) }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: "loantransactionapi-datasource-secret"
-  annotations:
-    "helm.sh/resource-policy": "keep"
-type: Opaque
-data:
-  {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "loantransactionapi-datasource-secret") | default dict }}
-  {{- $secretData := (get $secretObj "data") | default dict }}
-  {{- $dbSecret := (get $secretData "loantransactionapi-datasource-secret") | default (randAlphaNum 32 | b64enc) }}
-  password: {{ $dbSecret | quote }}
-{{- else }}
-{{- end }}
----
-{{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "loantransactionapi-liquibase-secret") }}
-{{- if and (not .Values.global.environment.config.loan_transaction_api.liquibase_password) (not $secretObj) }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: "loantransactionapi-liquibase-secret"
-  annotations:
-    "helm.sh/resource-policy": "keep"
-type: Opaque
-data:
-  {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "loantransactionapi-liquibase-secret") | default dict }}
-  {{- $secretData := (get $secretObj "data") | default dict }}
-  {{- $dbSecret := (get $secretData "loantransactionapi-liquibase-secret") | default (randAlphaNum 32 | b64enc) }}
-  password: {{ $dbSecret | quote }}
-{{- else }}
-{{- end }}
----
-{{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "agentapi-datasource-secret") }}
-{{- if and (not .Values.global.environment.config.agent_api.datasource_password) (not $secretObj) }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: "agentapi-datasource-secret"
-  annotations:
-    "helm.sh/resource-policy": "keep"
-type: Opaque
-data:
-  {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "agentapi-datasource-secret") | default dict }}
-  {{- $secretData := (get $secretObj "data") | default dict }}
-  {{- $dbSecret := (get $secretData "agentapi-datasource-secret") | default (randAlphaNum 32 | b64enc) }}
-  password: {{ $dbSecret | quote }}
-{{- else }}
-{{- end }}
----
-{{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "agentapi-liquibase-secret") }}
-{{- if and (not .Values.global.environment.config.agent_api.liquibase_password) (not $secretObj) }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: "agentapi-liquibase-secret"
-  annotations:
-    "helm.sh/resource-policy": "keep"
-type: Opaque
-data:
-  {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "agentapi-liquibase-secret") | default dict }}
-  {{- $secretData := (get $secretObj "data") | default dict }}
-  {{- $dbSecret := (get $secretData "agentapi-liquibase-secret") | default (randAlphaNum 32 | b64enc) }}
-  password: {{ $dbSecret | quote }}
-{{- else }}
-{{- end }}
----
-{{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "dinaexportapi-datasource-secret") }}
-{{- if and (not .Values.global.environment.config.dina_export_api.datasource_password) (not $secretObj) }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: "dinaexportapi-datasource-secret"
-  annotations:
-    "helm.sh/resource-policy": "keep"
-type: Opaque
-data:
-  {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "dinaexportapi-datasource-secret") | default dict }}
-  {{- $secretData := (get $secretObj "data") | default dict }}
-  {{- $dbSecret := (get $secretData "dinaexportapi-datasource-secret") | default (randAlphaNum 32 | b64enc) }}
-  password: {{ $dbSecret | quote }}
-{{- else }}
-{{- end }}
----
-{{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "dinaexportapi-liquibase-secret") }}
-{{- if and (not .Values.global.environment.config.dina_export_api.liquibase_password) (not $secretObj) }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: "dinaexportapi-liquibase-secret"
-  annotations:
-    "helm.sh/resource-policy": "keep"
-type: Opaque
-data:
-  {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "dinaexportapi-liquibase-secret") | default dict }}
-  {{- $secretData := (get $secretObj "data") | default dict }}
-  {{- $dbSecret := (get $secretData "dinaexportapi-liquibase-secret") | default (randAlphaNum 32 | b64enc) }}
-  password: {{ $dbSecret | quote }}
-{{- else }}
-{{- end }}
----
-{{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "seqdbapi-datasource-secret") }}
-{{- if and (not .Values.global.environment.config.seqdb_api.datasource_password) (not $secretObj) }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: "seqdbapi-datasource-secret"
-  annotations:
-    "helm.sh/resource-policy": "keep"
-type: Opaque
-data:
-  {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "seqdbapi-datasource-secret") | default dict }}
-  {{- $secretData := (get $secretObj "data") | default dict }}
-  {{- $dbSecret := (get $secretData "seqdbapi-datasource-secret") | default (randAlphaNum 32 | b64enc) }}
-  password: {{ $dbSecret | quote }}
-{{- else }}
-{{- end }}
----
-{{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "seqdbapi-liquibase-secret") }}
-{{- if and (not .Values.global.environment.config.seqdb_api.liquibase_password) (not $secretObj) }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: "seqdbapi-liquibase-secret"
-  annotations:
-    "helm.sh/resource-policy": "keep"
-type: Opaque
-data:
-  {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "seqdbapi-liquibase-secret") | default dict }}
-  {{- $secretData := (get $secretObj "data") | default dict }}
-  {{- $dbSecret := (get $secretData "seqdbapi-liquibase-secret") | default (randAlphaNum 32 | b64enc) }}
-  password: {{ $dbSecret | quote }}
-{{- else }}
-{{- end }}
----
-{{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "elasticsearch-secret") }}
-{{- if and (not .Values.global.environment.config.elasticsearch.password) (not $secretObj) }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: "elasticsearch-secret"
-  annotations:
-    "helm.sh/resource-policy": "keep"
-type: Opaque
-data:
-  {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "elasticsearch-secret") | default dict }}
-  {{- $secretData := (get $secretObj "data") | default dict }}
-  {{- $dbSecret := (get $secretData "elasticsearch-secret") | default (randAlphaNum 32 | b64enc) }}
-  password: {{ $dbSecret | quote }}
-{{- else }}
 {{- end }}


### PR DESCRIPTION
- Update `auto.secrets.yaml` to loop over values (hardcoded into the file) to generate different secrets instead of hardcoding each secret
  - improves maintainability
 
Tests:
- Compared diff of `helm template dina-helm .` before and after changes to confirm no adverse effects from changes
  - Also compared with `--set global.environment.isOpenShift=true` flag
  - Also compared when installing with custom values that `auto.secrets.yaml` depends on (e.g. `.Values.global.environment.config.dina_db.db_password`)
- Helm chart still runs fine on this branch