### PR TITLE
added missing keycloak config to loan-transaction-api

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -125,6 +125,8 @@ services:
       spring.liquibase.contexts: schema-change, initial-data, data-migration
       spring.datasource.username: ${LOAN_TRANSACTION_WEB_USER}
       spring.datasource.password: ${LOAN_TRANSACTION_WEB_USER_PW}
+      spring.security.oauth2.resourceserver.jwt.issuer-uri: ${KEYCLOAK_EXTERNAL_URL}/realms/dina
+      spring.security.oauth2.resourceserver.jwt.jwk-set-uri: ${KEYCLOAK_INTERNAL_URL}/realms/dina/protocol/openid-connect/certs
     networks:
       - dina
     extra_hosts:


### PR DESCRIPTION
Without this a clean checkout of the current dina-local-deployment will not start the loan-transaction-api module correctly